### PR TITLE
New cookie changes option: Update

### DIFF
--- a/library.js
+++ b/library.js
@@ -438,7 +438,7 @@ plugin.addMiddleware = async function (req, res, next) {
 	if (
 		!plugin.ready ||	// plugin not ready
 		(plugin.settings.behaviour === 'trust' && hasSession) ||	// user logged in + "trust" behaviour
-		(plugin.settings.behaviour === 'revalidate' && hasLoginLock) ||
+		((plugin.settings.behaviour === 'revalidate' || plugin.settings.behaviour === 'update') && hasLoginLock) ||
 		req.originalUrl.startsWith(nconf.get('relative_path') + '/api')	// api routes
 	) {
 		// Let requests through under "revalidate" behaviour only if they're logging in for the first time
@@ -525,7 +525,7 @@ plugin.addMiddleware = async function (req, res, next) {
 		} else if (hasSession) {
 			// Has login session but no cookie, can assume "revalidate" behaviour
 			user.isAdministrator(req.user.uid, function (err, isAdmin) {
-				if (plugin.settings.adminRevalidate === 'on' || !isAdmin) {
+				if (plugin.settings.behaviour !== 'update' && (plugin.settings.adminRevalidate === 'on' || !isAdmin)) {
 					req.logout();
 					res.locals.fullRefresh = true;
 					handleGuest(req, res, next);

--- a/static/templates/admin/plugins/session-sharing.tpl
+++ b/static/templates/admin/plugins/session-sharing.tpl
@@ -46,6 +46,7 @@
 						<select class="form-control" name="behaviour" id="behaviour">
 							<option value="trust">"Trust" &rarr; Shared cookie token used once only to authenticate, session persists even if cookie cleared</option>
 							<option value="revalidate">"Revalidate" &rarr; Shared cookie is checked on every page load, and updated/logged out to reflect changes in cookie</option>
+							<option value="update">"Update" &rarr; Shared cookie is checked on every page load, and updated to reflect changes in cookie. But user is not logged out when cookie is missing</option>
 						</select>
 					</div>
 					<div class="checkbox">


### PR DESCRIPTION
Hi,
we need a functionality that is something between Trust and Revalidate cookie options:
- Users are not logged out when the session sharing cookie is missing (Trust)
- User profile is updated when the session sharing cookie contains new information (Revalidate)

I created new cookie option called 'Update' that does both things. The name, or the settings description might be a subject to change of course.

Thanks
Tomas