### PR TITLE
fix: add password page to edit redirect

### DIFF
--- a/library.js
+++ b/library.js
@@ -392,7 +392,7 @@ plugin.addMiddleware = async function ({ req, res }) {
 		return;
 	}
 
-	if (editOverride && hasSession && req.originalUrl.match(/\/user\/.*\/edit$/)) {
+	if (editOverride && hasSession && req.originalUrl.match(/\/user\/.*\/edit(\/\w+)?$/)) {
 		return res.redirect(editOverride.replace('%1', encodeURIComponent(req.protocol + '://' + req.get('host') + req.originalUrl)));
 	}
 	if (loginOverride && req.originalUrl.match(/\/login$/)) {

--- a/static/lib/main.js
+++ b/static/lib/main.js
@@ -20,7 +20,7 @@ $(document).ready(function () {
 	}
 
 	function isEditUrl(url) {
-		return url.match(/^user\/.*\/edit$/);
+		return url.match(/^user\/.*\/edit(\/\w+)?$/);
 	}
 
 	$(window).on('action:app.loggedOut', function (evt, data) {


### PR DESCRIPTION
Hi,
the redirects from edit profile were missing the page where user can change its password.

I thought about making this as another option to settings, but I think a simple "fix" is better.

Thanks,
Tomas