### PR TITLE
fix: do not reroll sessions for update behaviour

### DIFF
--- a/library.js
+++ b/library.js
@@ -421,7 +421,7 @@ plugin.addMiddleware = async function ({ req, res }) {
 			winston.verbose('[session-sharing] Processing login for uid ' + uid + ', path ' + req.originalUrl);
 			req.uid = uid;
 
-			if (plugin.settings.behaviour === 'revalidate') {
+			if (plugin.settings.behaviour === 'revalidate' || plugin.settings.behaviour === 'update') {
 				res.locals.reroll = false;	// disable session rerolling in core
 			}
 


### PR DESCRIPTION
Hi there,
sessions should not be rerolled with update behaviour.

The problem that is caused by this is that when you open multiple tabs, you will exceed maximum number of sessions and you will be logged out. It took me some time to find this out.

Thanks,
Tomas